### PR TITLE
Pin openpyxl to 3.0.10

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ python_requires = >=3.6
 install_requires =
 	importlib_metadata
 	plover>=4.0.0.dev9
+ 	openpyxl==3.0.10
 	pyexcel>=0.4.5
 	pyexcel-ods>=0.6.0
 	pyexcel-xlsx>=0.3.0


### PR DESCRIPTION
Fixes #3 by following guidance from the linked thread https://github.com/pyexcel/pyexcel-xlsx/issues/52: pinning openpyxl to version 3.0.10.